### PR TITLE
Bug bounty - EthAtl hackathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Note the refresh token, vault id and vault key id. Each of these values will be 
 You can use the following command to run a `full` node on the Baseledger "peachtree" testnet:
 
 ```
+PROVIDE_REFRESH_TOKEN=<your access token> \
 VAULT_REFRESH_TOKEN=<your refresh token> \
 VAULT_ID=<vault id> \
 VAULT_KEY_ID=<vault key id> \
@@ -146,25 +147,25 @@ after the number of block confirmations. The number of L1 confirmations required
 Baseledger network recognizing any associated updates (e.g., changes to the validator set) is
 determined based on which EVM-based network is hosting the staking and token contracts:
 
-| Network | Block Confirmations |
-|--|--|
-| mainnet | 30 |
-| ropsten | 3 |
+| Network | Block Confirmations          |
+| ------- | ---------------------------- |
+| mainnet | 30                           |
+| ropsten | 3                            |
 | rinkeby | _not supported at this time_ |
-| kovan | _not supported at this time_ |
-| goerli | _not supported at this time_ |
+| kovan   | _not supported at this time_ |
+| goerli  | _not supported at this time_ |
 
 ## Staking Contract
 
 A [staking contract](https://github.com/Baseledger/baseledger-contracts/blob/master/contracts/Staking.sol), initialized with a reference to the UBT token contract address, is deployed on the following Ethereum networks:
 
-| Network | Symbol | Token Contract Address | Staking Contract Address |
-|--|--|--|--|
-| mainnet | UBT | `0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e` | -- |
-| ropsten | UBTR | `0xa9a466b8f415bcc5883934eda70016f8b23ea776` | `0x0B5FC75192F8EE3B4795AB44b3B455aB3d97A6dF` |
-| rinkeby | -- | -- | -- |
-| kovan | -- | -- | -- |
-| goerli | -- | -- | -- |
+| Network | Symbol | Token Contract Address                       | Staking Contract Address                     |
+| ------- | ------ | -------------------------------------------- | -------------------------------------------- |
+| mainnet | UBT    | `0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e` | --                                           |
+| ropsten | UBTR   | `0xa9a466b8f415bcc5883934eda70016f8b23ea776` | `0x0B5FC75192F8EE3B4795AB44b3B455aB3d97A6dF` |
+| rinkeby | --     | --                                           | --                                           |
+| kovan   | --     | --                                           | --                                           |
+| goerli  | --     | --                                           | --                                           |
 
 ### Faucet
 
@@ -209,7 +210,7 @@ way of governance approval or, in primitive/testnet setups, implicit approval.
 Staking contract source can be found [here](https://github.com/Baseledger/baseledger-contracts/blob/master/contracts/Staking.sol#L42).
 Example transaction on Ropsten can be found [here](https://ropsten.etherscan.io/tx/0x6f222afc6ee868f09c2738a13ef4508ba1022fd5f2f3d06c4dc63e5901fd4997).
 
-#### `withdraw(uint256 amount) external` 
+#### `withdraw(uint256 amount) external`
 
 Initiate the withdrawal of a portion, or all, of a previously deposited stake from the
 configured staking contract; the following example contract call to the staking contract on the "peachtree: testnet (`0x0B5FC75192F8EE3B4795AB44b3B455aB3d97A6dF`) results in 10,000 UBTR being withdrawn from our depositor account on the staking contract and returned.

--- a/common/config.go
+++ b/common/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	VaultKeyID        *uuid.UUID `json:"vault_key_id"`
 	VaultRefreshToken *string    `json:"-"`
 
-	ProvideRefreshToken    *string `json:"-"`
+	ProvideAccessToken    *string `json:"-"`
 	StakingContractAddress *string `json:"staking_contract_address"`
 	StakingNetwork         *string `json:"staking_network"`
 }
@@ -289,9 +289,9 @@ func ConfigFactory() (*Config, error) {
 	p2pPrivatePeerIDs := os.Getenv("BASELEDGER_PRIVATE_PEER_IDS")
 	p2pSeedPeers := os.Getenv("BASELEDGER_SEEDS")
 
-	var provideRefreshToken *string
-	if os.Getenv("PROVIDE_REFRESH_TOKEN") != "" {
-		provideRefreshToken = common.StringOrNil(os.Getenv("PROVIDE_REFRESH_TOKEN"))
+	var provideAccessToken *string
+	if os.Getenv("PROVIDE_ACCESS_TOKEN") != "" {
+		provideAccessToken = common.StringOrNil(os.Getenv("PROVIDE_ACCESS_TOKEN"))
 	}
 
 	var vaultRefreshToken string
@@ -394,7 +394,7 @@ func ConfigFactory() (*Config, error) {
 				LogFormat: logFormat,
 
 				// NodeKey json path
-				NodeKey: fmt.Sprintf("%s%snode.json", rootPath, string(os.PathSeparator)),
+				NodeKey: fmt.Sprintf("%s%sconfig.json", rootPath, string(os.PathSeparator)),
 
 				// Mechanism to connect to the ABCI application: socket | grpc
 				ABCI: abciConnectionType,
@@ -692,7 +692,7 @@ func ConfigFactory() (*Config, error) {
 		GenesisURL:      genesisURL,
 		GenesisStateURL: genesisStateURL,
 
-		ProvideRefreshToken:    provideRefreshToken,
+		ProvideAccessToken:    provideAccessToken,
 		StakingContractAddress: stakingContractAddress,
 		StakingNetwork:         common.StringOrNil(stakingNetwork),
 

--- a/protocol/service.go
+++ b/protocol/service.go
@@ -56,12 +56,12 @@ func authorizeAccessToken(refreshToken string) (*ident.Token, error) {
 }
 
 func serviceFactory(cfg *common.Config, genesis *types.GenesisDoc) (*Service, error) {
-	if cfg.ProvideRefreshToken == nil {
-		common.Log.Debug("baseline protocol service implementation not configured; no bearer refresh token provided")
+	if cfg.ProvideAccessToken == nil {
+		common.Log.Debug("baseline protocol service implementation not configured; no Provide api access token provided")
 		return nil, nil
 	}
 
-	token, err := authorizeAccessToken(*cfg.ProvideRefreshToken)
+	token, err := authorizeAccessToken(*cfg.ProvideAccessToken)
 	if err != nil {
 		common.Log.Panicf("failed to initialize baseline protocol service implementation; bearer access token not authorized; %s", err.Error())
 	}


### PR DESCRIPTION
Fixes a few bugs:

- Use config.json file instead of trying to search for non-existent node.json
- Add PROVIDE_ACCESS_TOKEN to environment variables
  - Gets passed in initializing command
  - Value set to "access token" that is returned in `prvd api_tokens init`
  - Added instruction in README